### PR TITLE
docs(format): properly layout the header docs

### DIFF
--- a/BCScanner/BCScannerViewController.h
+++ b/BCScanner/BCScannerViewController.h
@@ -41,55 +41,56 @@ extern NSString *const BCScannerEAN8Code;
 
 
 /**
- * BCScannerViewController is a view controller that wrapps the scanning capabilities
- * of iOS7 into a simple to use drop-in view controller for easy integration into your app.
- *
- * It is build for the purpose of scanning a single or multiple codes in a deticated screen
- * and encapsules all the camera handling and metadata gathering.
- * 
- * The view controller can be presented or pushed onto a navigation stack. It is up to you
- * to present and dismiss the view controller whenever you need it.
- */
+ BCScannerViewController is a view controller that wrapps the scanning
+ capabilities of iOS7 into a simple to use drop-in view controller for easy
+ integration into your app.
+ 
+ It is build for the purpose of scanning a single or multiple codes in a
+ deticated screen and encapsules all the camera handling and metadata gathering.
+ 
+ The view controller can be presented or pushed onto a navigation stack. It is
+ up to you to present and dismiss the view controller whenever you need it.
+*/
 @interface BCScannerViewController : UIViewController
 
 /**
- * This method lets you check for the availability of the native scanner functionality
- * provided by AVFoundation.
- *
- * @note	Do not instanciate this class if this method returns NO!
- *
- * @return	YES if native scanning is available, NO otherwise.
+ This method lets you check for the availability of the native scanner
+ functionality provided by AVFoundation.
+
+ @note Do not instanciate this class if this method returns NO!
+
+ @return YES if native scanning is available, NO otherwise.
  */
 + (BOOL)scannerAvailable;
 
 /**
- * This is the delegate of the scanner. The delegate will get called to notify you about
- * codes that were found in the field of view of the camera.
+ This is the delegate of the scanner. The delegate will get called to notify you
+ about codes that were found in the field of view of the camera.
  */
 @property (nonatomic, weak, readwrite) id<BCScannerViewControllerDelegate> delegate;
 
 /**
- * This is an array of the codes the scanner should look for. The more code types you
- * specify, the longer the image analysis will take!
- *
- * @see BCScannerCode constants
+ This is an array of the codes the scanner should look for. The more code types
+ you specify, the longer the image analysis will take!
+
+ @see BCScannerCode constants
  */
 @property (nonatomic, strong, readwrite) NSArray *codeTypes;
 
 /**
- * This is the gesture recognizer that is used to let the user focus and expose to a
- * specific point in the field of view. You can access this property when you want to
- * more precisely control what taps should be recognized.
+ This is the gesture recognizer that is used to let the user focus and expose to
+ a specific point in the field of view. You can access this property when you
+ want to more precisely control what taps should be recognized.
  */
 @property (nonatomic, weak, readonly) UITapGestureRecognizer *focusAndExposeGestureRecognizer;
 
 /**
- * Defines the rect of the view controller's view that describes the active area
- * that is used by `AVFoundation` to scan for barcodes.
- *
- * @note all codes that are completely visible by the active camera and
- *       intersect with the specified area are scanned. The code does not need
- *       to be completely inside the scanner area.
+ Defines the rect of the view controller's view that describes the active area
+ that is used by `AVFoundation` to scan for barcodes.
+
+ @note all codes that are completely visible by the active camera and intersect
+       with the specified area are scanned. The code does not need to be
+       completely inside the scanner area.
  */
 @property (nonatomic, assign, readwrite) CGRect scannerArea;
 
@@ -98,18 +99,19 @@ extern NSString *const BCScannerEAN8Code;
 #pragma mark - torch
 
 /**
- *  Defines the video preview torch mode.
+ Defines the video preview torch mode.
  */
 @property (nonatomic, assign, readwrite, getter = isTorchEnabled) BOOL torchEnabled;
 
 /**
- *  Hides or displays the torch button in the navigation bar.
- *  The default value is YES.
+ Hides or displays the torch button in the navigation bar.
+ 
+ The default value is YES.
  */
 @property (nonatomic, assign, readwrite, getter = isTorchButtonEnabled) BOOL torchButtonEnabled;
 
 /**
- *  Indicates if the torch mode is available. Varies depending on the device.
+ Indicates if the torch mode is available. Varies depending on the device.
  */
 @property (nonatomic, assign, readonly, getter = isTorchModeAvailable) BOOL torchModeAvailable;
 
@@ -120,34 +122,35 @@ extern NSString *const BCScannerEAN8Code;
 
 @optional
 /**
- * This method is called whenever a new code enters the field of view.
- *
- * @param	scanner	The scanner that is calling this delegate
- * @param	codes	A list of all the codes that entered the FOV in this interval
- *
- * @note	If you do a simple scan for the first code you find, you can get the code
- *			from this method and close the scanner afterwards.
+ This method is called whenever a new code enters the field of view.
+
+ @param	scanner	The scanner that is calling this delegate
+ @param	codes	A list of all the codes that entered the FOV in this interval
+
+ @note	If you do a simple scan for the first code you find, you can get the
+        code from this method and close the scanner afterwards.
  */
 - (void)scanner:(BCScannerViewController *)scanner codesDidEnterFOV:(NSSet *)codes;
 
 //- (void)scanner:(BCScannerViewController *)scanner codesDidUpdate:(NSSet *)codes;
 
 /**
- * This method is called whenever an existing code leaves the field of view.
- *
- * @param	scanner	The scanner that is calling this delegate
- * @param	codes	A list of all the codes that left the FOV in this interval
+ This method is called whenever an existing code leaves the field of view.
+
+ @param	scanner	The scanner that is calling this delegate
+ @param	codes	A list of all the codes that left the FOV in this interval
  */
 - (void)scanner:(BCScannerViewController *)scanner codesDidLeaveFOV:(NSSet *)codes;
 
 /**
- * This method lets you specify an image that is shown as an overlay to give the user
- * some feedback about how to hold the camera.
- *
- * This method is called when the scanner configures its interface.
- *
- * @param	scanner	The scanner that is calling this delegate
- * @return	The image you want to be used as HUD
+ This method lets you specify an image that is shown as an overlay to give the
+ user some feedback about how to hold the camera.
+
+ This method is called when the scanner configures its interface.
+
+ @param scanner	The scanner that is calling this delegate
+ 
+ @return The image you want to be used as HUD
  */
 - (UIImage *)scannerHUDImage:(BCScannerViewController *)scanner;
 

--- a/BCScanner/UIViewController+BCScanner.h
+++ b/BCScanner/UIViewController+BCScanner.h
@@ -30,7 +30,8 @@
        cancelled the scanner, no completion handler is called!
  
  @param codeTypes         An array of all code types that should be scanned for
- @param completionHandler The completion handler that is called when a code is found
+ @param completionHandler The completion handler that is called when a code is
+                          found
  
  @return The created view controller. You can configure this view controller.
  */


### PR DESCRIPTION
This PR removes leading asterisks (*) in front of comment lines and ensures that each commenting line has a maximum column width of 80 characters.

fix #10
