### PR TITLE
feat(hud): add possibility to specify a hud image in block based api

### DIFF
--- a/BCScanner/Private/BCScannerDelegate.h
+++ b/BCScanner/Private/BCScannerDelegate.h
@@ -21,6 +21,8 @@
 
 @property (nonatomic, copy, readonly) void(^completionHandler)(NSString *code);
 
+@property (nonatomic, strong, readwrite) UIImage *hudImage;
+
 /**
  Initializes a new delegate object that call the completion handler when a
  scanner view controller finds the first code.

--- a/BCScanner/Private/BCScannerDelegate.m
+++ b/BCScanner/Private/BCScannerDelegate.m
@@ -47,4 +47,8 @@
 	[scanner dismissViewControllerAnimated:YES completion:NULL];
 }
 
+- (UIImage *)scannerHUDImage:(BCScannerViewController *)scanner {
+	return self.hudImage;
+}
+
 @end

--- a/BCScanner/UIViewController+BCScanner.h
+++ b/BCScanner/UIViewController+BCScanner.h
@@ -37,4 +37,6 @@
  */
 - (BCScannerViewController *)bcscanner_presentScannerWithCodeTypes:(NSArray *)codeTypes completionHandler:(void(^)(NSString *code))completionHandler;
 
+- (BCScannerViewController *)bcscanner_presentScannerWithCodeTypes:(NSArray *)codeTypes hudImage:(UIImage *)hudImage completionHandler:(void(^)(NSString *code))completionHandler;
+
 @end

--- a/BCScanner/UIViewController+BCScanner.m
+++ b/BCScanner/UIViewController+BCScanner.m
@@ -27,11 +27,17 @@ static void *const BCScannerDelegateContext = (void *)&BCScannerDelegateContext;
 
 - (BCScannerViewController *)bcscanner_presentScannerWithCodeTypes:(NSArray *)codeTypes completionHandler:(void(^)(NSString *code))completionHandler
 {
+	return [self bcscanner_presentScannerWithCodeTypes:codeTypes hudImage:nil completionHandler:completionHandler];
+}
+
+- (BCScannerViewController *)bcscanner_presentScannerWithCodeTypes:(NSArray *)codeTypes hudImage:(UIImage *)hudImage completionHandler:(void(^)(NSString *code))completionHandler
+{
 	if (![BCScannerViewController scannerAvailable]) {
 		return nil;
 	}
 	
 	BCScannerDelegate *delegate = [BCScannerDelegate delegateWithCompletionHandler:completionHandler];
+	delegate.hudImage = hudImage;
 	
 	BCScannerViewController *viewController = [BCScannerViewController new];
 	viewController.delegate = delegate;

--- a/Example/BCScannerExample/MainViewController.m
+++ b/Example/BCScannerExample/MainViewController.m
@@ -42,7 +42,7 @@
 
 - (IBAction)openScannerBlockBased:(id)sender
 {
-	[self bcscanner_presentScannerWithCodeTypes:@[ BCScannerQRCode ] completionHandler:^(NSString *code) {
+	[self bcscanner_presentScannerWithCodeTypes:@[ BCScannerQRCode ] hudImage:[UIImage imageNamed:@"HUD"] completionHandler:^(NSString *code) {
 		NSLog(@"Found: [%@]", code);
 	}];
 }


### PR DESCRIPTION
This PR closes #17 

It adds another block based API call, that lets you specify an image that is used as a HUD image.
