### PR TITLE
Feature/#7 full avfoundation support

### DIFF
--- a/BCScanner/BCScannerViewController.h
+++ b/BCScanner/BCScannerViewController.h
@@ -25,21 +25,21 @@
 #pragma mark - code types
 
 // iOS7+
-FOUNDATION_EXTERN NSString *const BCScannerUPCECode;
-FOUNDATION_EXTERN NSString *const BCScannerCode39Code;
-FOUNDATION_EXTERN NSString *const BCScannerCode39Mod43Code;
-FOUNDATION_EXTERN NSString *const BCScannerEAN13Code;
-FOUNDATION_EXTERN NSString *const BCScannerEAN8Code;
-FOUNDATION_EXTERN NSString *const BCScannerCode93Code;
-FOUNDATION_EXTERN NSString *const BCScannerCode128Code;
-FOUNDATION_EXTERN NSString *const BCScannerPDF417Code;
-FOUNDATION_EXTERN NSString *const BCScannerQRCode;
-FOUNDATION_EXTERN NSString *const BCScannerAztecCode;
+FOUNDATION_EXTERN NSString *const BCScannerUPCECode; /// The UPC-E code type.
+FOUNDATION_EXTERN NSString *const BCScannerCode39Code; /// The code 39 code type.
+FOUNDATION_EXTERN NSString *const BCScannerCode39Mod43Code; /// The code 39 code type with mod 43 support.
+FOUNDATION_EXTERN NSString *const BCScannerEAN13Code; /// The EAN 13 code type.
+FOUNDATION_EXTERN NSString *const BCScannerEAN8Code; /// The EAN 8 code type.
+FOUNDATION_EXTERN NSString *const BCScannerCode93Code; /// The code 93 code type.
+FOUNDATION_EXTERN NSString *const BCScannerCode128Code; /// The code 128 code type.
+FOUNDATION_EXTERN NSString *const BCScannerPDF417Code; /// The PDF 417 code type.
+FOUNDATION_EXTERN NSString *const BCScannerQRCode; /// The QR code type.
+FOUNDATION_EXTERN NSString *const BCScannerAztecCode; /// The aztec code type.
 
 // iOS8+
-FOUNDATION_EXTERN NSString *const BCScannerI25Code;
-FOUNDATION_EXTERN NSString *const BCScannerITF14Code;
-FOUNDATION_EXTERN NSString *const BCScannerDataMatrixCode;
+FOUNDATION_EXTERN NSString *const BCScannerI25Code; /// The Interleaved 2 of 5 code type. This type does nothing on iOS7, as it is only supported on iOS8 and later
+FOUNDATION_EXTERN NSString *const BCScannerITF14Code; /// The ITF14 code type. This type does nothing on iOS7, as it is only supported on iOS8 and later
+FOUNDATION_EXTERN NSString *const BCScannerDataMatrixCode; /// The data matrix code type. This type does nothing on iOS7, as it is only supported on iOS8 and later
 
 
 

--- a/BCScanner/BCScannerViewController.h
+++ b/BCScanner/BCScannerViewController.h
@@ -19,27 +19,31 @@
 
 #import <UIKit/UIKit.h>
 
-
-extern NSString *const BCScannerQRCode; /// The code type used for QR codes.
-extern NSString *const BCScannerUPCECode;
-extern NSString *const BCScannerI25Code;
-
-//extern NSString *const BCScannerCode39Code;
-//extern NSString *const BCScannerCode39Mod43Code;
-
-extern NSString *const BCScannerEAN13Code;
-extern NSString *const BCScannerEAN8Code;
-
-//extern NSString *const BCScannerCode93Code;
-//extern NSString *const BCScannerCode128Code;
-//extern NSString *const BCScannerPDF417Code;
-//extern NSString *const BCScannerAztecCode;
-
-
-
-
 @protocol BCScannerViewControllerDelegate;
 
+
+#pragma mark - code types
+
+// iOS7+
+FOUNDATION_EXTERN NSString *const BCScannerUPCECode;
+FOUNDATION_EXTERN NSString *const BCScannerCode39Code;
+FOUNDATION_EXTERN NSString *const BCScannerCode39Mod43Code;
+FOUNDATION_EXTERN NSString *const BCScannerEAN13Code;
+FOUNDATION_EXTERN NSString *const BCScannerEAN8Code;
+FOUNDATION_EXTERN NSString *const BCScannerCode93Code;
+FOUNDATION_EXTERN NSString *const BCScannerCode128Code;
+FOUNDATION_EXTERN NSString *const BCScannerPDF417Code;
+FOUNDATION_EXTERN NSString *const BCScannerQRCode;
+FOUNDATION_EXTERN NSString *const BCScannerAztecCode;
+
+// iOS8+
+FOUNDATION_EXTERN NSString *const BCScannerI25Code;
+FOUNDATION_EXTERN NSString *const BCScannerITF14Code;
+FOUNDATION_EXTERN NSString *const BCScannerDataMatrixCode;
+
+
+
+#pragma mark - controller
 
 /**
  BCScannerViewController is a view controller that wrapps the scanning
@@ -121,6 +125,9 @@ extern NSString *const BCScannerEAN8Code;
 
 @end
 
+
+
+#pragma mark - delegate
 
 @protocol BCScannerViewControllerDelegate <NSObject>
 

--- a/BCScanner/BCScannerViewController.m
+++ b/BCScanner/BCScannerViewController.m
@@ -24,20 +24,39 @@
 @import AVFoundation;
 
 
-NSString *const BCScannerQRCode = @"BCScannerQRCode";
+// iOS7+
+// AVMetadataObjectTypeUPCECode;
+// AVMetadataObjectTypeCode39Code;
+// AVMetadataObjectTypeCode39Mod43Code;
+// AVMetadataObjectTypeEAN13Code;
+// AVMetadataObjectTypeEAN8Code;
+// AVMetadataObjectTypeCode93Code;
+// AVMetadataObjectTypeCode128Code;
+// AVMetadataObjectTypePDF417Code;
+// AVMetadataObjectTypeQRCode;
+// AVMetadataObjectTypeAztecCode;
+//
+// iOS8+
+// AVMetadataObjectTypeInterleaved2of5Code;
+// AVMetadataObjectTypeITF14Code;
+// AVMetadataObjectTypeDataMatrixCode
+
+// iOS7+
 NSString *const BCScannerUPCECode = @"BCScannerUPCECode";
-NSString *const BCScannerI25Code = @"BCScannerI25Code";
-
-//NSString *const BCScannerCode39Code = @"BCScannerCode39Code";
-//NSString *const BCScannerCode39Mod43Code = @"BCScannerCode39Mod43Code";
-
+NSString *const BCScannerCode39Code = @"BCScannerCode39Code";
+NSString *const BCScannerCode39Mod43Code = @"BCScannerCode39Mod43Code";
 NSString *const BCScannerEAN13Code = @"BCScannerEAN13Code";
 NSString *const BCScannerEAN8Code = @"BCScannerEAN8Code";
+NSString *const BCScannerCode93Code = @"BCScannerCode93Code";
+NSString *const BCScannerCode128Code = @"BCScannerCode128Code";
+NSString *const BCScannerPDF417Code = @"BCScannerPDF417Code";
+NSString *const BCScannerQRCode = @"BCScannerQRCode";
+NSString *const BCScannerAztecCode = @"BCScannerAztecCode";
 
-//NSString *const BCScannerCode93Code = @"BCScannerCode93Code";
-//NSString *const BCScannerCode128Code = @"BCScannerCode128Code";
-//NSString *const BCScannerPDF417Code = @"BCScannerPDF417Code";
-//NSString *const BCScannerAztecCode = @"BCScannerAztecCode";
+// iOS8+
+NSString *const BCScannerI25Code = @"BCScannerI25Code";
+NSString *const BCScannerITF14Code = @"BCScannerITF14Code";
+NSString *const BCScannerDataMatrixCode = @"BCScannerDataMatrixCode";
 
 
 @interface BCScannerViewController () <AVCaptureMetadataOutputObjectsDelegate>
@@ -92,40 +111,63 @@ static inline CGRect HUDRect(CGRect bounds, UIEdgeInsets padding, CGFloat aspect
 
 + (NSNumber *)aspectRatioForCode:(NSString *)code
 {
-	static NSMutableDictionary *aspectRatios = nil;
+	static NSDictionary *aspectRatios = nil;
 	static dispatch_once_t onceToken;
 	dispatch_once(&onceToken, ^{
-		aspectRatios =  [NSMutableDictionary
-						 dictionaryWithDictionary:@{
-													BCScannerQRCode: @1,
-													BCScannerEAN8Code: @1.1833333333,
-													BCScannerEAN13Code: @1.4198113208,
-													BCScannerUPCECode: @0.8538812785 }]; // horizontal
-		// add AVMetadataObjectTypeInterleaved2of5Code if iOS8+
-		if(&AVMetadataObjectTypeInterleaved2of5Code){
-			[aspectRatios setObject:@1.5 forKey:BCScannerI25Code];
-		}
+		// horizontal
+		aspectRatios = @{
+						 BCScannerUPCECode: @0.8538812785,
+						 BCScannerCode39Code: @1.7777777, // variable lenght, random value
+						 BCScannerCode39Mod43Code: @1.7777777, // variable lenght, random value
+						 BCScannerEAN13Code: @1.4198113208,
+						 BCScannerEAN8Code: @1.1833333333,
+						 BCScannerCode93Code: @1.7777777, // variable lenght, random value
+						 BCScannerCode128Code: @1.7777777, // variable lenght, random value
+						 BCScannerPDF417Code: @4.381, //approx.
+						 BCScannerQRCode: @1,
+						 BCScannerAztecCode: @1,
+						 
+						 BCScannerI25Code: @1.5,
+						 BCScannerITF14Code: @3.685, //approx.
+						 BCScannerDataMatrixCode: @1,
+						 };
 	});
 	return aspectRatios[code];
 }
 
 + (NSString *)metadataObjectTypeFromScannerCode:(NSString *)code
 {
-	static NSMutableDictionary *objectTypes = nil;
+	static NSDictionary *objectTypes = nil;
 	static dispatch_once_t onceToken;
 	dispatch_once(&onceToken, ^{
+		objectTypes = @{
+						BCScannerUPCECode: AVMetadataObjectTypeUPCECode,
+						BCScannerCode39Code: AVMetadataObjectTypeCode39Code,
+						BCScannerCode39Mod43Code: AVMetadataObjectTypeCode39Mod43Code,
+						BCScannerEAN13Code: AVMetadataObjectTypeEAN13Code,
+						BCScannerEAN8Code: AVMetadataObjectTypeEAN8Code,
+						BCScannerCode93Code: AVMetadataObjectTypeCode93Code,
+						BCScannerCode128Code: AVMetadataObjectTypeCode128Code,
+						BCScannerPDF417Code: AVMetadataObjectTypePDF417Code,
+						BCScannerQRCode: AVMetadataObjectTypeQRCode,
+						BCScannerAztecCode: AVMetadataObjectTypeAztecCode,
+						};
 		
-		objectTypes = [NSMutableDictionary
-					   dictionaryWithDictionary:@{
-												  BCScannerQRCode: AVMetadataObjectTypeQRCode,
-												  BCScannerEAN8Code: AVMetadataObjectTypeEAN8Code,
-												  BCScannerEAN13Code: AVMetadataObjectTypeEAN13Code,
-												  BCScannerUPCECode: AVMetadataObjectTypeUPCECode }];
-		// add AVMetadataObjectTypeInterleaved2of5Code if iOS8+
-		if(&AVMetadataObjectTypeInterleaved2of5Code){
-			[objectTypes setObject:AVMetadataObjectTypeInterleaved2of5Code forKey:BCScannerI25Code];
+		NSMutableDictionary *optionalCodeTypes = [NSMutableDictionary new];
+		if (&AVMetadataObjectTypeInterleaved2of5Code) {
+			optionalCodeTypes[BCScannerI25Code] = AVMetadataObjectTypeInterleaved2of5Code;
+		}
+		if (&AVMetadataObjectTypeITF14Code) {
+			optionalCodeTypes[BCScannerITF14Code] = AVMetadataObjectTypeITF14Code;
+		}
+		if (&AVMetadataObjectTypeDataMatrixCode) {
+			optionalCodeTypes[BCScannerDataMatrixCode] = AVMetadataObjectTypeDataMatrixCode;
 		}
 		
+		if (optionalCodeTypes.count > 0) {
+			[optionalCodeTypes addEntriesFromDictionary:objectTypes];
+			objectTypes = [optionalCodeTypes copy];
+		}
 	});
 	return objectTypes[code];
 }
@@ -420,8 +462,8 @@ static inline CGRect HUDRect(CGRect bounds, UIEdgeInsets padding, CGFloat aspect
 	NSMutableSet *objectsAdded = [NSMutableSet setWithSet:objectsStillLiving];
 	[objectsAdded minusSet:self.codesInFOV];
 	
-//	NSMutableSet *objectsUpdated = [NSMutableSet setWithSet:objectsStillLiving];
-//	[objectsUpdated intersectSet:self.codesInFOV];
+	//	NSMutableSet *objectsUpdated = [NSMutableSet setWithSet:objectsStillLiving];
+	//	[objectsUpdated intersectSet:self.codesInFOV];
 	
 	NSMutableSet *objectsMissing = [NSMutableSet setWithSet:self.codesInFOV];
 	[objectsMissing minusSet:objectsStillLiving];
@@ -432,9 +474,9 @@ static inline CGRect HUDRect(CGRect bounds, UIEdgeInsets padding, CGFloat aspect
 		if (objectsAdded.count > 0 && [self.delegate respondsToSelector:@selector(scanner:codesDidEnterFOV:)]) {
 			[self.delegate scanner:self codesDidEnterFOV:[objectsAdded copy]];
 		}
-//		if (objectsUpdated.count > 0 && [self.delegate respondsToSelector:@selector(scanner:codesDidUpdate:)]) {
-//			[self.delegate scanner:self codesDidUpdate:[objectsUpdated copy]];
-//		}
+		//		if (objectsUpdated.count > 0 && [self.delegate respondsToSelector:@selector(scanner:codesDidUpdate:)]) {
+		//			[self.delegate scanner:self codesDidUpdate:[objectsUpdated copy]];
+		//		}
 		if (objectsMissing.count > 0 && [self.delegate respondsToSelector:@selector(scanner:codesDidLeaveFOV:)]) {
 			[self.delegate scanner:self codesDidLeaveFOV:[objectsMissing copy]];
 		}

--- a/Example/BCScanner.xcodeproj/project.pbxproj
+++ b/Example/BCScanner.xcodeproj/project.pbxproj
@@ -1,1245 +1,572 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>archiveVersion</key>
-	<string>1</string>
-	<key>classes</key>
-	<dict/>
-	<key>objectVersion</key>
-	<string>46</string>
-	<key>objects</key>
-	<dict>
-		<key>44D254B662064F1BB6EBFEC8</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-BCScannerExample.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Pods-BCScannerExample.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>498E41D937E044979A668BFD</key>
-		<dict>
-			<key>fileRef</key>
-			<string>939579A71EEF45F684396ACC</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4C168B9A17E4745000D9404D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>4C168BBC17E4745100D9404D</string>
-				<string>4C168BD917E4A30600D9404D</string>
-				<string>4C168BA517E4745000D9404D</string>
-				<string>4C168BA417E4745000D9404D</string>
-				<string>F9AEBEB0AA904E18BE4FEC2C</string>
-				<string>44D254B662064F1BB6EBFEC8</string>
-				<string>E978E4E267054A3CA36CFB5C</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168B9B17E4745000D9404D</key>
-		<dict>
-			<key>attributes</key>
-			<dict>
-				<key>LastUpgradeCheck</key>
-				<string>0500</string>
-				<key>ORGANIZATIONNAME</key>
-				<string>Michael Ochs</string>
-				<key>TargetAttributes</key>
-				<dict>
-					<key>4C168BB217E4745100D9404D</key>
-					<dict>
-						<key>TestTargetID</key>
-						<string>4C168BD317E4A30600D9404D</string>
-					</dict>
-				</dict>
-			</dict>
-			<key>buildConfigurationList</key>
-			<string>4C168B9E17E4745000D9404D</string>
-			<key>compatibilityVersion</key>
-			<string>Xcode 3.2</string>
-			<key>developmentRegion</key>
-			<string>English</string>
-			<key>hasScannedForEncodings</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXProject</string>
-			<key>knownRegions</key>
-			<array>
-				<string>en</string>
-			</array>
-			<key>mainGroup</key>
-			<string>4C168B9A17E4745000D9404D</string>
-			<key>productRefGroup</key>
-			<string>4C168BA417E4745000D9404D</string>
-			<key>projectDirPath</key>
-			<string></string>
-			<key>projectReferences</key>
-			<array/>
-			<key>projectRoot</key>
-			<string></string>
-			<key>targets</key>
-			<array>
-				<string>4C168BB217E4745100D9404D</string>
-				<string>4C168BD317E4A30600D9404D</string>
-			</array>
-		</dict>
-		<key>4C168B9E17E4745000D9404D</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>4C168BC417E4745100D9404D</string>
-				<string>4C168BC517E4745100D9404D</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>4C168BA417E4745000D9404D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>4C168BB317E4745100D9404D</string>
-				<string>4C168BD417E4A30600D9404D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Products</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168BA517E4745000D9404D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>4C168C0A17E4A99E00D9404D</string>
-				<string>4C168BA617E4745000D9404D</string>
-				<string>4C168BB417E4745100D9404D</string>
-				<string>4C168BB717E4745100D9404D</string>
-				<string>4C168BD617E4A30600D9404D</string>
-				<string>91C37C188D0041E9A845B891</string>
-				<string>F6EF8D0F93C14BE7A2124721</string>
-				<string>939579A71EEF45F684396ACC</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Frameworks</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168BA617E4745000D9404D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>Foundation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/Foundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>4C168BAF17E4745100D9404D</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>4C168BC317E4745100D9404D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>4C168BB017E4745100D9404D</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>4C168BB517E4745100D9404D</string>
-				<string>4C168BB817E4745100D9404D</string>
-				<string>4C168BB617E4745100D9404D</string>
-				<string>D14BE04BED99480FBE1FD210</string>
-				<string>498E41D937E044979A668BFD</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>4C168BB117E4745100D9404D</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>4C168BC117E4745100D9404D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>4C168BB217E4745100D9404D</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>4C168BC917E4745100D9404D</string>
-			<key>buildPhases</key>
-			<array>
-				<string>97D92FC018014D0D8AC0FCE8</string>
-				<string>4C168BAF17E4745100D9404D</string>
-				<string>4C168BB017E4745100D9404D</string>
-				<string>4C168BB117E4745100D9404D</string>
-				<string>E758E41672C249D7A7B0EA49</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>BCScannerTests</string>
-			<key>productName</key>
-			<string>BCSannerTests</string>
-			<key>productReference</key>
-			<string>4C168BB317E4745100D9404D</string>
-			<key>productType</key>
-			<string>com.apple.product-type.bundle.unit-test</string>
-		</dict>
-		<key>4C168BB317E4745100D9404D</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.cfbundle</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>BCScannerTests.xctest</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>4C168BB417E4745100D9404D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>XCTest.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/XCTest.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>4C168BB517E4745100D9404D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4C168BB417E4745100D9404D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4C168BB617E4745100D9404D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4C168BA617E4745000D9404D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4C168BB717E4745100D9404D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>UIKit.framework</string>
-			<key>path</key>
-			<string>Library/Frameworks/UIKit.framework</string>
-			<key>sourceTree</key>
-			<string>DEVELOPER_DIR</string>
-		</dict>
-		<key>4C168BB817E4745100D9404D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4C168BB717E4745100D9404D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4C168BBC17E4745100D9404D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>4C168BC217E4745100D9404D</string>
-				<string>4C168BBD17E4745100D9404D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>BCSannerTests</string>
-			<key>path</key>
-			<string>BCScannerTests</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168BBD17E4745100D9404D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>4C168BBE17E4745100D9404D</string>
-				<string>4C168BBF17E4745100D9404D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168BBE17E4745100D9404D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>BCScannerTests-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168BBF17E4745100D9404D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>4C168BC017E4745100D9404D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168BC017E4745100D9404D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168BC117E4745100D9404D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4C168BBF17E4745100D9404D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4C168BC217E4745100D9404D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>BCScannerTests.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168BC317E4745100D9404D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4C168BC217E4745100D9404D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4C168BC417E4745100D9404D</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_DYNAMIC_NO_PIC</key>
-				<string>NO</string>
-				<key>GCC_OPTIMIZATION_LEVEL</key>
-				<string>0</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>GCC_SYMBOLS_PRIVATE_EXTERN</key>
-				<string>NO</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>ONLY_ACTIVE_ARCH</key>
-				<string>YES</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>4C168BC517E4745100D9404D</key>
-		<dict>
-			<key>buildSettings</key>
-			<dict>
-				<key>ALWAYS_SEARCH_USER_PATHS</key>
-				<string>NO</string>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>CLANG_CXX_LANGUAGE_STANDARD</key>
-				<string>gnu++0x</string>
-				<key>CLANG_CXX_LIBRARY</key>
-				<string>libc++</string>
-				<key>CLANG_ENABLE_MODULES</key>
-				<string>YES</string>
-				<key>CLANG_ENABLE_OBJC_ARC</key>
-				<string>YES</string>
-				<key>CLANG_WARN_BOOL_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_CONSTANT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_DIRECT_OBJC_ISA_USAGE</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN_EMPTY_BODY</key>
-				<string>YES</string>
-				<key>CLANG_WARN_ENUM_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_INT_CONVERSION</key>
-				<string>YES</string>
-				<key>CLANG_WARN_OBJC_ROOT_CLASS</key>
-				<string>YES_ERROR</string>
-				<key>CLANG_WARN__DUPLICATE_METHOD_MATCH</key>
-				<string>YES</string>
-				<key>COPY_PHASE_STRIP</key>
-				<string>YES</string>
-				<key>ENABLE_NS_ASSERTIONS</key>
-				<string>NO</string>
-				<key>GCC_C_LANGUAGE_STANDARD</key>
-				<string>gnu99</string>
-				<key>GCC_WARN_64_TO_32_BIT_CONVERSION</key>
-				<string>YES</string>
-				<key>GCC_WARN_ABOUT_RETURN_TYPE</key>
-				<string>YES_ERROR</string>
-				<key>GCC_WARN_UNDECLARED_SELECTOR</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNINITIALIZED_AUTOS</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_FUNCTION</key>
-				<string>YES</string>
-				<key>GCC_WARN_UNUSED_VARIABLE</key>
-				<string>YES</string>
-				<key>IPHONEOS_DEPLOYMENT_TARGET</key>
-				<string>7.0</string>
-				<key>SDKROOT</key>
-				<string>iphoneos</string>
-				<key>VALIDATE_PRODUCT</key>
-				<string>YES</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>4C168BC917E4745100D9404D</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>4C168BCA17E4745100D9404D</string>
-				<string>4C168BCB17E4745100D9404D</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>4C168BCA17E4745100D9404D</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>E978E4E267054A3CA36CFB5C</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>BUNDLE_LOADER</key>
-				<string>$(BUILT_PRODUCTS_DIR)/BCScannerExample.app/BCScannerExample</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>BCScanner/BCScanner-Prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>INFOPLIST_FILE</key>
-				<string>BCScannerTests/BCScannerTests-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>TEST_HOST</key>
-				<string>$(BUNDLE_LOADER)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>4C168BCB17E4745100D9404D</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>E978E4E267054A3CA36CFB5C</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>BUNDLE_LOADER</key>
-				<string>$(BUILT_PRODUCTS_DIR)/BCScannerExample.app/BCScannerExample</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(SDKROOT)/Developer/Library/Frameworks</string>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>BCScanner/BCScanner-Prefix.pch</string>
-				<key>INFOPLIST_FILE</key>
-				<string>BCScannerTests/BCScannerTests-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>TEST_HOST</key>
-				<string>$(BUNDLE_LOADER)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>xctest</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>4C168BD017E4A30600D9404D</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>4C168BE417E4A30600D9404D</string>
-				<string>4C168C0317E4A3AE00D9404D</string>
-				<string>4C168BE017E4A30600D9404D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXSourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>4C168BD117E4A30600D9404D</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>4C168C0B17E4A99E00D9404D</string>
-				<string>4C168BD717E4A30600D9404D</string>
-				<string>4C168BD817E4A30600D9404D</string>
-				<string>4C168BD517E4A30600D9404D</string>
-				<string>9FCC48589273438391D1B039</string>
-			</array>
-			<key>isa</key>
-			<string>PBXFrameworksBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>4C168BD217E4A30600D9404D</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array>
-				<string>4C168C0017E4A33200D9404D</string>
-				<string>4C168BDE17E4A30600D9404D</string>
-				<string>4C168BE617E4A30600D9404D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXResourcesBuildPhase</string>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-		</dict>
-		<key>4C168BD317E4A30600D9404D</key>
-		<dict>
-			<key>buildConfigurationList</key>
-			<string>4C168BF917E4A30600D9404D</string>
-			<key>buildPhases</key>
-			<array>
-				<string>9D8E866EF4D34B98BE9322E3</string>
-				<string>4C168BD017E4A30600D9404D</string>
-				<string>4C168BD117E4A30600D9404D</string>
-				<string>4C168BD217E4A30600D9404D</string>
-				<string>D3910FF268CD4D0BA11FEF8F</string>
-			</array>
-			<key>buildRules</key>
-			<array/>
-			<key>dependencies</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXNativeTarget</string>
-			<key>name</key>
-			<string>BCScannerExample</string>
-			<key>productName</key>
-			<string>BCScannerExample</string>
-			<key>productReference</key>
-			<string>4C168BD417E4A30600D9404D</string>
-			<key>productType</key>
-			<string>com.apple.product-type.application</string>
-		</dict>
-		<key>4C168BD417E4A30600D9404D</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>wrapper.application</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>BCScannerExample.app</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>4C168BD517E4A30600D9404D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4C168BA617E4745000D9404D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4C168BD617E4A30600D9404D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>CoreGraphics.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/CoreGraphics.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>4C168BD717E4A30600D9404D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4C168BD617E4A30600D9404D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4C168BD817E4A30600D9404D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4C168BB717E4745100D9404D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4C168BD917E4A30600D9404D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>4C168BE217E4A30600D9404D</string>
-				<string>4C168BE317E4A30600D9404D</string>
-				<string>4C168C0117E4A3AE00D9404D</string>
-				<string>4C168C0217E4A3AE00D9404D</string>
-				<string>4C168BE517E4A30600D9404D</string>
-				<string>4C168BDA17E4A30600D9404D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>path</key>
-			<string>BCScannerExample</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168BDA17E4A30600D9404D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>4C168BDB17E4A30600D9404D</string>
-				<string>4C168BDC17E4A30600D9404D</string>
-				<string>4C168BDF17E4A30600D9404D</string>
-				<string>4C168BE117E4A30600D9404D</string>
-				<string>4C168BFF17E4A33200D9404D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXGroup</string>
-			<key>name</key>
-			<string>Supporting Files</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168BDB17E4A30600D9404D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.xml</string>
-			<key>path</key>
-			<string>BCScannerExample-Info.plist</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168BDC17E4A30600D9404D</key>
-		<dict>
-			<key>children</key>
-			<array>
-				<string>4C168BDD17E4A30600D9404D</string>
-			</array>
-			<key>isa</key>
-			<string>PBXVariantGroup</string>
-			<key>name</key>
-			<string>InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168BDD17E4A30600D9404D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.plist.strings</string>
-			<key>name</key>
-			<string>en</string>
-			<key>path</key>
-			<string>en.lproj/InfoPlist.strings</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168BDE17E4A30600D9404D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4C168BDC17E4A30600D9404D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4C168BDF17E4A30600D9404D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>main.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168BE017E4A30600D9404D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4C168BDF17E4A30600D9404D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4C168BE117E4A30600D9404D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>BCScannerExample-Prefix.pch</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168BE217E4A30600D9404D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>AppDelegate.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168BE317E4A30600D9404D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>AppDelegate.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168BE417E4A30600D9404D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4C168BE317E4A30600D9404D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4C168BE517E4A30600D9404D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>folder.assetcatalog</string>
-			<key>path</key>
-			<string>Images.xcassets</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168BE617E4A30600D9404D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4C168BE517E4A30600D9404D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4C168BF917E4A30600D9404D</key>
-		<dict>
-			<key>buildConfigurations</key>
-			<array>
-				<string>4C168BFA17E4A30600D9404D</string>
-				<string>4C168BFB17E4A30600D9404D</string>
-			</array>
-			<key>defaultConfigurationIsVisible</key>
-			<string>0</string>
-			<key>defaultConfigurationName</key>
-			<string>Release</string>
-			<key>isa</key>
-			<string>XCConfigurationList</string>
-		</dict>
-		<key>4C168BFA17E4A30600D9404D</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>44D254B662064F1BB6EBFEC8</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME</key>
-				<string>LaunchImage</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>BCScannerExample/BCScannerExample-Prefix.pch</string>
-				<key>GCC_PREPROCESSOR_DEFINITIONS</key>
-				<array>
-					<string>DEBUG=1</string>
-					<string>$(inherited)</string>
-				</array>
-				<key>HEADER_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include</string>
-				</array>
-				<key>INFOPLIST_FILE</key>
-				<string>BCScannerExample/BCScannerExample-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>app</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Debug</string>
-		</dict>
-		<key>4C168BFB17E4A30600D9404D</key>
-		<dict>
-			<key>baseConfigurationReference</key>
-			<string>44D254B662064F1BB6EBFEC8</string>
-			<key>buildSettings</key>
-			<dict>
-				<key>ARCHS</key>
-				<string>$(ARCHS_STANDARD_INCLUDING_64_BIT)</string>
-				<key>ASSETCATALOG_COMPILER_APPICON_NAME</key>
-				<string>AppIcon</string>
-				<key>ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME</key>
-				<string>LaunchImage</string>
-				<key>CODE_SIGN_IDENTITY[sdk=iphoneos*]</key>
-				<string>iPhone Developer</string>
-				<key>FRAMEWORK_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>$(DEVELOPER_FRAMEWORKS_DIR)</string>
-				</array>
-				<key>GCC_PRECOMPILE_PREFIX_HEADER</key>
-				<string>YES</string>
-				<key>GCC_PREFIX_HEADER</key>
-				<string>BCScannerExample/BCScannerExample-Prefix.pch</string>
-				<key>HEADER_SEARCH_PATHS</key>
-				<array>
-					<string>$(inherited)</string>
-					<string>/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include</string>
-				</array>
-				<key>INFOPLIST_FILE</key>
-				<string>BCScannerExample/BCScannerExample-Info.plist</string>
-				<key>PRODUCT_NAME</key>
-				<string>$(TARGET_NAME)</string>
-				<key>WRAPPER_EXTENSION</key>
-				<string>app</string>
-			</dict>
-			<key>isa</key>
-			<string>XCBuildConfiguration</string>
-			<key>name</key>
-			<string>Release</string>
-		</dict>
-		<key>4C168BFF17E4A33200D9404D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>file.storyboard</string>
-			<key>path</key>
-			<string>MainStoryboard.storyboard</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168C0017E4A33200D9404D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4C168BFF17E4A33200D9404D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4C168C0117E4A3AE00D9404D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.h</string>
-			<key>path</key>
-			<string>MainViewController.h</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168C0217E4A3AE00D9404D</key>
-		<dict>
-			<key>fileEncoding</key>
-			<string>4</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>sourcecode.c.objc</string>
-			<key>path</key>
-			<string>MainViewController.m</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>4C168C0317E4A3AE00D9404D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4C168C0217E4A3AE00D9404D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>4C168C0A17E4A99E00D9404D</key>
-		<dict>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>wrapper.framework</string>
-			<key>name</key>
-			<string>AVFoundation.framework</string>
-			<key>path</key>
-			<string>System/Library/Frameworks/AVFoundation.framework</string>
-			<key>sourceTree</key>
-			<string>SDKROOT</string>
-		</dict>
-		<key>4C168C0B17E4A99E00D9404D</key>
-		<dict>
-			<key>fileRef</key>
-			<string>4C168C0A17E4A99E00D9404D</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>91C37C188D0041E9A845B891</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>939579A71EEF45F684396ACC</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-BCScannerTests.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>97D92FC018014D0D8AC0FCE8</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Check Pods Manifest.lock</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
-if [[ $? != 0 ]] ; then
-    cat &lt;&lt; EOM
-error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
-EOM
-    exit 1
-fi
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>9D8E866EF4D34B98BE9322E3</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Check Pods Manifest.lock</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>diff "${PODS_ROOT}/../Podfile.lock" "${PODS_ROOT}/Manifest.lock" &gt; /dev/null
-if [[ $? != 0 ]] ; then
-    cat &lt;&lt; EOM
-error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.
-EOM
-    exit 1
-fi
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>9FCC48589273438391D1B039</key>
-		<dict>
-			<key>fileRef</key>
-			<string>F6EF8D0F93C14BE7A2124721</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D14BE04BED99480FBE1FD210</key>
-		<dict>
-			<key>fileRef</key>
-			<string>91C37C188D0041E9A845B891</string>
-			<key>isa</key>
-			<string>PBXBuildFile</string>
-		</dict>
-		<key>D3910FF268CD4D0BA11FEF8F</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Pods-BCScannerExample-resources.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>E758E41672C249D7A7B0EA49</key>
-		<dict>
-			<key>buildActionMask</key>
-			<string>2147483647</string>
-			<key>files</key>
-			<array/>
-			<key>inputPaths</key>
-			<array/>
-			<key>isa</key>
-			<string>PBXShellScriptBuildPhase</string>
-			<key>name</key>
-			<string>Copy Pods Resources</string>
-			<key>outputPaths</key>
-			<array/>
-			<key>runOnlyForDeploymentPostprocessing</key>
-			<string>0</string>
-			<key>shellPath</key>
-			<string>/bin/sh</string>
-			<key>shellScript</key>
-			<string>"${SRCROOT}/Pods/Pods-BCScannerTests-resources.sh"
-</string>
-			<key>showEnvVarsInLog</key>
-			<string>0</string>
-		</dict>
-		<key>E978E4E267054A3CA36CFB5C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods-BCScannerTests.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Pods-BCScannerTests.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-		<key>F6EF8D0F93C14BE7A2124721</key>
-		<dict>
-			<key>explicitFileType</key>
-			<string>archive.ar</string>
-			<key>includeInIndex</key>
-			<string>0</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>path</key>
-			<string>libPods-BCScannerExample.a</string>
-			<key>sourceTree</key>
-			<string>BUILT_PRODUCTS_DIR</string>
-		</dict>
-		<key>F9AEBEB0AA904E18BE4FEC2C</key>
-		<dict>
-			<key>includeInIndex</key>
-			<string>1</string>
-			<key>isa</key>
-			<string>PBXFileReference</string>
-			<key>lastKnownFileType</key>
-			<string>text.xcconfig</string>
-			<key>name</key>
-			<string>Pods.xcconfig</string>
-			<key>path</key>
-			<string>Pods/Pods.xcconfig</string>
-			<key>sourceTree</key>
-			<string>&lt;group&gt;</string>
-		</dict>
-	</dict>
-	<key>rootObject</key>
-	<string>4C168B9B17E4745000D9404D</string>
-</dict>
-</plist>
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		498E41D937E044979A668BFD /* libPods-BCScannerTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 939579A71EEF45F684396ACC /* libPods-BCScannerTests.a */; };
+		4C168BB517E4745100D9404D /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C168BB417E4745100D9404D /* XCTest.framework */; };
+		4C168BB617E4745100D9404D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C168BA617E4745000D9404D /* Foundation.framework */; };
+		4C168BB817E4745100D9404D /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C168BB717E4745100D9404D /* UIKit.framework */; };
+		4C168BC117E4745100D9404D /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4C168BBF17E4745100D9404D /* InfoPlist.strings */; };
+		4C168BC317E4745100D9404D /* BCScannerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C168BC217E4745100D9404D /* BCScannerTests.m */; };
+		4C168BD517E4A30600D9404D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C168BA617E4745000D9404D /* Foundation.framework */; };
+		4C168BD717E4A30600D9404D /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C168BD617E4A30600D9404D /* CoreGraphics.framework */; };
+		4C168BD817E4A30600D9404D /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C168BB717E4745100D9404D /* UIKit.framework */; };
+		4C168BDE17E4A30600D9404D /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = 4C168BDC17E4A30600D9404D /* InfoPlist.strings */; };
+		4C168BE017E4A30600D9404D /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C168BDF17E4A30600D9404D /* main.m */; };
+		4C168BE417E4A30600D9404D /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C168BE317E4A30600D9404D /* AppDelegate.m */; };
+		4C168BE617E4A30600D9404D /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 4C168BE517E4A30600D9404D /* Images.xcassets */; };
+		4C168C0017E4A33200D9404D /* MainStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 4C168BFF17E4A33200D9404D /* MainStoryboard.storyboard */; };
+		4C168C0317E4A3AE00D9404D /* MainViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 4C168C0217E4A3AE00D9404D /* MainViewController.m */; };
+		4C168C0B17E4A99E00D9404D /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4C168C0A17E4A99E00D9404D /* AVFoundation.framework */; };
+		9FCC48589273438391D1B039 /* libPods-BCScannerExample.a in Frameworks */ = {isa = PBXBuildFile; fileRef = F6EF8D0F93C14BE7A2124721 /* libPods-BCScannerExample.a */; };
+		D14BE04BED99480FBE1FD210 /* libPods.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 91C37C188D0041E9A845B891 /* libPods.a */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		44D254B662064F1BB6EBFEC8 /* Pods-BCScannerExample.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BCScannerExample.xcconfig"; path = "Pods/Pods-BCScannerExample.xcconfig"; sourceTree = "<group>"; };
+		4C168BA617E4745000D9404D /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
+		4C168BB317E4745100D9404D /* BCScannerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BCScannerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		4C168BB417E4745100D9404D /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		4C168BB717E4745100D9404D /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
+		4C168BBE17E4745100D9404D /* BCScannerTests-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "BCScannerTests-Info.plist"; sourceTree = "<group>"; };
+		4C168BC017E4745100D9404D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		4C168BC217E4745100D9404D /* BCScannerTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = BCScannerTests.m; sourceTree = "<group>"; };
+		4C168BD417E4A30600D9404D /* BCScannerExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BCScannerExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		4C168BD617E4A30600D9404D /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
+		4C168BDB17E4A30600D9404D /* BCScannerExample-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = "BCScannerExample-Info.plist"; sourceTree = "<group>"; };
+		4C168BDD17E4A30600D9404D /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/InfoPlist.strings; sourceTree = "<group>"; };
+		4C168BDF17E4A30600D9404D /* main.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
+		4C168BE117E4A30600D9404D /* BCScannerExample-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "BCScannerExample-Prefix.pch"; sourceTree = "<group>"; };
+		4C168BE217E4A30600D9404D /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
+		4C168BE317E4A30600D9404D /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
+		4C168BE517E4A30600D9404D /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		4C168BFF17E4A33200D9404D /* MainStoryboard.storyboard */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.storyboard; path = MainStoryboard.storyboard; sourceTree = "<group>"; };
+		4C168C0117E4A3AE00D9404D /* MainViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MainViewController.h; sourceTree = "<group>"; };
+		4C168C0217E4A3AE00D9404D /* MainViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MainViewController.m; sourceTree = "<group>"; };
+		4C168C0A17E4A99E00D9404D /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
+		91C37C188D0041E9A845B891 /* libPods.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libPods.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		939579A71EEF45F684396ACC /* libPods-BCScannerTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BCScannerTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E978E4E267054A3CA36CFB5C /* Pods-BCScannerTests.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BCScannerTests.xcconfig"; path = "Pods/Pods-BCScannerTests.xcconfig"; sourceTree = "<group>"; };
+		F6EF8D0F93C14BE7A2124721 /* libPods-BCScannerExample.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BCScannerExample.a"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F9AEBEB0AA904E18BE4FEC2C /* Pods.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = Pods.xcconfig; path = Pods/Pods.xcconfig; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		4C168BB017E4745100D9404D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C168BB517E4745100D9404D /* XCTest.framework in Frameworks */,
+				4C168BB817E4745100D9404D /* UIKit.framework in Frameworks */,
+				4C168BB617E4745100D9404D /* Foundation.framework in Frameworks */,
+				D14BE04BED99480FBE1FD210 /* libPods.a in Frameworks */,
+				498E41D937E044979A668BFD /* libPods-BCScannerTests.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4C168BD117E4A30600D9404D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C168C0B17E4A99E00D9404D /* AVFoundation.framework in Frameworks */,
+				4C168BD717E4A30600D9404D /* CoreGraphics.framework in Frameworks */,
+				4C168BD817E4A30600D9404D /* UIKit.framework in Frameworks */,
+				4C168BD517E4A30600D9404D /* Foundation.framework in Frameworks */,
+				9FCC48589273438391D1B039 /* libPods-BCScannerExample.a in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		4C168B9A17E4745000D9404D = {
+			isa = PBXGroup;
+			children = (
+				4C168BBC17E4745100D9404D /* BCSannerTests */,
+				4C168BD917E4A30600D9404D /* BCScannerExample */,
+				4C168BA517E4745000D9404D /* Frameworks */,
+				4C168BA417E4745000D9404D /* Products */,
+				F9AEBEB0AA904E18BE4FEC2C /* Pods.xcconfig */,
+				44D254B662064F1BB6EBFEC8 /* Pods-BCScannerExample.xcconfig */,
+				E978E4E267054A3CA36CFB5C /* Pods-BCScannerTests.xcconfig */,
+			);
+			sourceTree = "<group>";
+		};
+		4C168BA417E4745000D9404D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				4C168BB317E4745100D9404D /* BCScannerTests.xctest */,
+				4C168BD417E4A30600D9404D /* BCScannerExample.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		4C168BA517E4745000D9404D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				4C168C0A17E4A99E00D9404D /* AVFoundation.framework */,
+				4C168BA617E4745000D9404D /* Foundation.framework */,
+				4C168BB417E4745100D9404D /* XCTest.framework */,
+				4C168BB717E4745100D9404D /* UIKit.framework */,
+				4C168BD617E4A30600D9404D /* CoreGraphics.framework */,
+				91C37C188D0041E9A845B891 /* libPods.a */,
+				F6EF8D0F93C14BE7A2124721 /* libPods-BCScannerExample.a */,
+				939579A71EEF45F684396ACC /* libPods-BCScannerTests.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		4C168BBC17E4745100D9404D /* BCSannerTests */ = {
+			isa = PBXGroup;
+			children = (
+				4C168BC217E4745100D9404D /* BCScannerTests.m */,
+				4C168BBD17E4745100D9404D /* Supporting Files */,
+			);
+			name = BCSannerTests;
+			path = BCScannerTests;
+			sourceTree = "<group>";
+		};
+		4C168BBD17E4745100D9404D /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				4C168BBE17E4745100D9404D /* BCScannerTests-Info.plist */,
+				4C168BBF17E4745100D9404D /* InfoPlist.strings */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		4C168BD917E4A30600D9404D /* BCScannerExample */ = {
+			isa = PBXGroup;
+			children = (
+				4C168BE217E4A30600D9404D /* AppDelegate.h */,
+				4C168BE317E4A30600D9404D /* AppDelegate.m */,
+				4C168C0117E4A3AE00D9404D /* MainViewController.h */,
+				4C168C0217E4A3AE00D9404D /* MainViewController.m */,
+				4C168BE517E4A30600D9404D /* Images.xcassets */,
+				4C168BDA17E4A30600D9404D /* Supporting Files */,
+			);
+			path = BCScannerExample;
+			sourceTree = "<group>";
+		};
+		4C168BDA17E4A30600D9404D /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				4C168BDB17E4A30600D9404D /* BCScannerExample-Info.plist */,
+				4C168BDC17E4A30600D9404D /* InfoPlist.strings */,
+				4C168BDF17E4A30600D9404D /* main.m */,
+				4C168BE117E4A30600D9404D /* BCScannerExample-Prefix.pch */,
+				4C168BFF17E4A33200D9404D /* MainStoryboard.storyboard */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		4C168BB217E4745100D9404D /* BCScannerTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4C168BC917E4745100D9404D /* Build configuration list for PBXNativeTarget "BCScannerTests" */;
+			buildPhases = (
+				97D92FC018014D0D8AC0FCE8 /* Check Pods Manifest.lock */,
+				4C168BAF17E4745100D9404D /* Sources */,
+				4C168BB017E4745100D9404D /* Frameworks */,
+				4C168BB117E4745100D9404D /* Resources */,
+				E758E41672C249D7A7B0EA49 /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BCScannerTests;
+			productName = BCSannerTests;
+			productReference = 4C168BB317E4745100D9404D /* BCScannerTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		4C168BD317E4A30600D9404D /* BCScannerExample */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 4C168BF917E4A30600D9404D /* Build configuration list for PBXNativeTarget "BCScannerExample" */;
+			buildPhases = (
+				9D8E866EF4D34B98BE9322E3 /* Check Pods Manifest.lock */,
+				4C168BD017E4A30600D9404D /* Sources */,
+				4C168BD117E4A30600D9404D /* Frameworks */,
+				4C168BD217E4A30600D9404D /* Resources */,
+				D3910FF268CD4D0BA11FEF8F /* Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BCScannerExample;
+			productName = BCScannerExample;
+			productReference = 4C168BD417E4A30600D9404D /* BCScannerExample.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		4C168B9B17E4745000D9404D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0500;
+				ORGANIZATIONNAME = "Michael Ochs";
+				TargetAttributes = {
+					4C168BB217E4745100D9404D = {
+						TestTargetID = 4C168BD317E4A30600D9404D;
+					};
+					4C168BD317E4A30600D9404D = {
+						DevelopmentTeam = 2K8K37TB9L;
+					};
+				};
+			};
+			buildConfigurationList = 4C168B9E17E4745000D9404D /* Build configuration list for PBXProject "BCScanner" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 4C168B9A17E4745000D9404D;
+			productRefGroup = 4C168BA417E4745000D9404D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				4C168BD317E4A30600D9404D /* BCScannerExample */,
+				4C168BB217E4745100D9404D /* BCScannerTests */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		4C168BB117E4745100D9404D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C168BC117E4745100D9404D /* InfoPlist.strings in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4C168BD217E4A30600D9404D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C168C0017E4A33200D9404D /* MainStoryboard.storyboard in Resources */,
+				4C168BDE17E4A30600D9404D /* InfoPlist.strings in Resources */,
+				4C168BE617E4A30600D9404D /* Images.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		97D92FC018014D0D8AC0FCE8 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		9D8E866EF4D34B98BE9322E3 /* Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Check Pods Manifest.lock";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_ROOT}/../Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [[ $? != 0 ]] ; then\n    cat << EOM\nerror: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\nEOM\n    exit 1\nfi\n";
+			showEnvVarsInLog = 0;
+		};
+		D3910FF268CD4D0BA11FEF8F /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Pods-BCScannerExample-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+		E758E41672C249D7A7B0EA49 /* Copy Pods Resources */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Copy Pods Resources";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${SRCROOT}/Pods/Pods-BCScannerTests-resources.sh\"\n";
+			showEnvVarsInLog = 0;
+		};
+/* End PBXShellScriptBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		4C168BAF17E4745100D9404D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C168BC317E4745100D9404D /* BCScannerTests.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		4C168BD017E4A30600D9404D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				4C168BE417E4A30600D9404D /* AppDelegate.m in Sources */,
+				4C168C0317E4A3AE00D9404D /* MainViewController.m in Sources */,
+				4C168BE017E4A30600D9404D /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		4C168BBF17E4745100D9404D /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				4C168BC017E4745100D9404D /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+		4C168BDC17E4A30600D9404D /* InfoPlist.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				4C168BDD17E4A30600D9404D /* en */,
+			);
+			name = InfoPlist.strings;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		4C168BC417E4745100D9404D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		4C168BC517E4745100D9404D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		4C168BCA17E4745100D9404D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E978E4E267054A3CA36CFB5C /* Pods-BCScannerTests.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/BCScannerExample.app/BCScannerExample";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "BCScanner/BCScanner-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = "BCScannerTests/BCScannerTests-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Debug;
+		};
+		4C168BCB17E4745100D9404D /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = E978E4E267054A3CA36CFB5C /* Pods-BCScannerTests.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/BCScannerExample.app/BCScannerExample";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(SDKROOT)/Developer/Library/Frameworks",
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "BCScanner/BCScanner-Prefix.pch";
+				INFOPLIST_FILE = "BCScannerTests/BCScannerTests-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUNDLE_LOADER)";
+				WRAPPER_EXTENSION = xctest;
+			};
+			name = Release;
+		};
+		4C168BFA17E4A30600D9404D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44D254B662064F1BB6EBFEC8 /* Pods-BCScannerExample.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "BCScannerExample/BCScannerExample-Prefix.pch";
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+				);
+				INFOPLIST_FILE = "BCScannerExample/BCScannerExample-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Debug;
+		};
+		4C168BFB17E4A30600D9404D /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 44D254B662064F1BB6EBFEC8 /* Pods-BCScannerExample.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
+				FRAMEWORK_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(DEVELOPER_FRAMEWORKS_DIR)",
+				);
+				GCC_PRECOMPILE_PREFIX_HEADER = YES;
+				GCC_PREFIX_HEADER = "BCScannerExample/BCScannerExample-Prefix.pch";
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+				);
+				INFOPLIST_FILE = "BCScannerExample/BCScannerExample-Info.plist";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE = "";
+				WRAPPER_EXTENSION = app;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		4C168B9E17E4745000D9404D /* Build configuration list for PBXProject "BCScanner" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4C168BC417E4745100D9404D /* Debug */,
+				4C168BC517E4745100D9404D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4C168BC917E4745100D9404D /* Build configuration list for PBXNativeTarget "BCScannerTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4C168BCA17E4745100D9404D /* Debug */,
+				4C168BCB17E4745100D9404D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		4C168BF917E4A30600D9404D /* Build configuration list for PBXNativeTarget "BCScannerExample" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				4C168BFA17E4A30600D9404D /* Debug */,
+				4C168BFB17E4A30600D9404D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 4C168B9B17E4745000D9404D /* Project object */;
+}

--- a/Example/BCScannerExample/MainViewController.m
+++ b/Example/BCScannerExample/MainViewController.m
@@ -29,12 +29,16 @@
 
 @implementation MainViewController
 
++ (NSArray *)allCodeTypes {
+	return @[ BCScannerUPCECode, BCScannerCode39Code, BCScannerCode39Mod43Code, BCScannerEAN13Code, BCScannerEAN8Code, BCScannerCode93Code, BCScannerCode128Code, BCScannerPDF417Code, BCScannerQRCode, BCScannerAztecCode, BCScannerI25Code, BCScannerITF14Code, BCScannerDataMatrixCode ];
+}
+
 - (IBAction)openScanner:(id)sender
 {
 	if ([BCScannerViewController scannerAvailable]) {
 		BCScannerViewController *scanner = [[BCScannerViewController alloc] init];
 		scanner.delegate = self;
-		scanner.codeTypes = @[ BCScannerQRCode, BCScannerEAN8Code, BCScannerEAN13Code, BCScannerUPCECode ];
+		scanner.codeTypes = [MainViewController allCodeTypes];
 		scanner.torchButtonEnabled = YES;
 		[self.navigationController pushViewController:scanner animated:YES];
 	}
@@ -42,7 +46,7 @@
 
 - (IBAction)openScannerBlockBased:(id)sender
 {
-	[self bcscanner_presentScannerWithCodeTypes:@[ BCScannerQRCode, BCScannerI25Code ] hudImage:[UIImage imageNamed:@"HUD"] completionHandler:^(NSString *code) {
+	[self bcscanner_presentScannerWithCodeTypes:[MainViewController allCodeTypes] hudImage:[UIImage imageNamed:@"HUD"] completionHandler:^(NSString *code) {
 		NSLog(@"Found: [%@]", code);
 	}];
 }


### PR DESCRIPTION
This PR adds full support for all code types that are currently supported by AVFoundation. It ensures that code types that became available on iOS8 can safely be assigned as code types on iOS7 but they do nothing there. You do not need to worry about checking iOS versions.

Fixes #7 
