### PR TITLE
fix(orientation): orientation updates upon initialization.

### DIFF
--- a/BCScanner/BCScannerViewController.m
+++ b/BCScanner/BCScannerViewController.m
@@ -289,6 +289,7 @@ NSString *const BCScannerDataMatrixCode = @"BCScannerDataMatrixCode";
 {
 	[super viewWillAppear:animated];
 	
+	self.previewView.videoOrientation = (AVCaptureVideoOrientation)[[UIApplication sharedApplication] statusBarOrientation]; // The enum defs for UIInterfaceOrientation and AVCaptureVideoOrientation are the same!
 	[self.session startRunning];
 }
 


### PR DESCRIPTION
Hello,
I've encountered a nasty interface orientation bug. 
- **Symptoms:** The video preview layer shows camera image rotated by multiples of 90 degrees. The image returns to normal only after at least one interface orientation change.
- **Steps to reproduce:** Launch BCScannerViewController in interface orientation different than portrait.
- **Tested on:** iPad 2 running iOS 8.3

I've attached a simple single-line fix.
Hope it helps!

Peter.
